### PR TITLE
ltp: Run "mm" as the default test

### DIFF
--- a/tests/ltp.sh
+++ b/tests/ltp.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-TESTS="${TESTS-syscalls -s madvise}"
+TESTS="${TESTS-mm}"
 LTP_PATH="${LTP_PATH-/opt/ltp}"
 LOGS="/tmp/LTP_$(date +%s)_"
 


### PR DESCRIPTION
This is a better choice for a default.

Signed-off-by: Andy Doan <andy@foundries.io>