### PR TITLE
Dockerfile: move to debian containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # Build Python Deps------------------------------------------------------------
-FROM ubuntu:20.04 as pydeps
+FROM rust:bullseye as pydeps
 
 # python3-curl is built with gnutls so we build it by hand
 RUN apt update && \
-	apt install -y gcc libcurl4-openssl-dev libffi-dev libssh-dev python3-pip python3-dev rustc cargo
+    DEBIAN_FRONTEND=noninteractive apt install -y gcc openssl libcurl4-openssl-dev libssl-dev pkg-config libffi-dev libssh-dev python3-pip python3-dev git
+RUN python3 -m pip install -U pip setuptools
+RUN CARGO_NET_GIT_FETCH_WITH_CLI=true pip3 -v install --no-cache-dir cryptography
 RUN pip3 install pycurl==7.43.0.6
 RUN pip3 install asyncssh==2.2.1 netifaces==0.10.9 requests==2.23.0 pyyaml==5.3.1 pydantic==1.5.1
 
 # Build Container -------------------------------------------------------------
-FROM ubuntu:20.04
+FROM debian:bullseye
 
 # opensc install tzdata which requires user input without this:
 ENV TZ=UTC
@@ -21,9 +23,9 @@ RUN \
 	ln -s /usr/lib/*-linux-gnu/engines-1.1 /usr/lib/engines-1.1 && \
 	rm -rf /var/lib/apt/lists/*
 
-COPY --from=pydeps /usr/local/lib/python3.8/dist-packages/ /usr/local/lib/python3.8/dist-packages/
+COPY --from=pydeps /usr/local/lib/python3.9/dist-packages/ /usr/local/lib/python3.9/dist-packages/
 COPY ./bin/* /usr/local/bin/
 COPY ./tests /usr/share/fio-tests
-COPY ./fiotest /usr/local/lib/python3.8/dist-packages/fiotest
+COPY ./fiotest /usr/local/lib/python3.9/dist-packages/fiotest
 COPY ./aklite-callback.sh /
 COPY ./trigger-target-tests.sh /


### PR DESCRIPTION
This change fixes the build issues with ubuntu and python cryptography on armhf.