### PR TITLE
Change EXPOSE to ensure port 8000 is only available on localhost #13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     privileged: true
     command: python3 -m fiotest.main /test-spec.yml
     ports:
-      - 8000:${PORT-8000}
+      - 127.0.0.1:8000:${PORT-8000}
     volumes:
       - ${SOTA_CONFD-/etc/sota/conf.d}:/etc/sota/conf.d
       - ${SOTA_DIR-/var/sota}:/var/sota


### PR DESCRIPTION
The default example exposes the webserver port 8000 on the local network.

We can restrict this to localhost only which I believe will still support any fiotest testing requirements (?)