### PR TITLE
EDGE-3062: FIO_TEST_ env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,9 @@ sequence:
           - /usr/share/fio-tests/ltp.sh
 ...
 ~~~
+
+## Custom Environment Variables
+
+- `FIO_TEST_DEBUG`: enable debug mode by setting the environment variable to "true".  Default to debug mode disabled. When debug mode is enabled, logs from /tmp/fio-test- are not deleted
+- `FIO_TEST_DOCKER_HOST`: set the Docker host IP used to run tests on the host directly.  Defaults to `172.17.0.1`.
+- `FIO_TEST_DRYRUN`: enable dry run mode by setting the environment variable to "true". Default to dry run disabled.  When dry run is disabled, test results are not reported to Foundries.  For backwards compatability, setting `DRYRUN` to any string should also enable dry run mode.

--- a/bin/fio-test-wrap
+++ b/bin/fio-test-wrap
@@ -7,6 +7,7 @@ import subprocess
 import sys
 
 from fiotest.api import API, status
+from fiotest.environment import debug_mode, dry_run
 
 here = os.path.dirname(os.path.abspath(__file__))
 
@@ -108,12 +109,12 @@ def main(sota_dir: str, test: str, test_cmd: List[str], dryrun: bool):
     try:
         api.complete_test(test_id, data, artifacts_dir)
     finally:
-        rmtree(tmpdir)
+        if not debug_mode():
+            rmtree(tmpdir)
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
         sys.exit("Usage: %s <test-name> <test command>..." % sys.argv[0])
     sota_dir = os.environ.get("SOTA_DIR", "/var/sota")
-    dryrun = os.environ.get("DRYRUN")
-    main(sota_dir, sys.argv[1], sys.argv[2:], dryrun)
+    main(sota_dir, sys.argv[1], sys.argv[2:], dry_run())

--- a/fiotest/environment.py
+++ b/fiotest/environment.py
@@ -1,0 +1,28 @@
+"""Fiotest environment module."""
+
+import os
+
+
+_TRUES = ("1", "true", "yes", "on")
+
+
+def _get_bools(env_var: str, default: bool) -> bool:
+    """Get boolean value from environment variable."""
+    if env_var not in os.environ:
+        return default
+    return os.environ.get(env_var).lower() in _TRUES
+
+
+def docker_host() -> str:
+    """Get the docker host IP address."""
+    return os.environ.get("FIO_TEST_DOCKER_HOST", "172.17.0.1")
+
+
+def debug_mode() -> bool:
+    """Check if debug mode is enabled."""
+    return _get_bools("FIO_TEST_DEBUG", False)
+
+
+def dry_run() -> bool:
+    """Check if dry run mode is enabled."""
+    return _get_bools("FIO_TEST_DRYRUN", os.environ.get("DRYRUN"))

--- a/fiotest/host.py
+++ b/fiotest/host.py
@@ -3,10 +3,12 @@ import asyncssh
 import sys
 from typing import Optional
 
+from environment import docker_host
+
 
 def _host_connect():
     return asyncssh.connect(
-        "172.17.0.1", known_hosts=None, username="fio", password="fio"
+        docker_host(), known_hosts=None, username="fio", password="fio"
     )
 
 

--- a/fiotest/main.py
+++ b/fiotest/main.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 import os
-import sys
 from threading import Timer
 
 import yaml


### PR DESCRIPTION
Mainspring is working on implementing some fiotests to run.  At the moment, to run checks on the host device, the IP address is hard coded in the `host.py` file; however, Mainspring has changed the Foundries default to a different value, and the current implementation does not enable us to run any tests in the host environment.

My primary goal is to enable us to configure the IP without forking your whole repo; this is _a_ proposed way to set the the IP address to use, but open to other suggestions.

Looking through the rest of the code, I also wanted to 
* add a way to enable keeping the logs in `/tmp/fio-test-` while developing -- by default the logs are removed as part of cleanup, and while this is useful and the desired behavior in general, some of these logs look useful for us while we're iterating
* set `DRYRUN` following the same env var pattern -- this was the only other variable I thought users may want to change during development, so I changed the env var name to follow the same `FIO_TEST_*` pattern

(but these are less necessary).

---

I'm happy to iterate, but if there's lots of opinions over implementation, let's focus on the IP address issue.